### PR TITLE
fix(Dockerfile): Remove double labels

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,11 +1,7 @@
 FROM centos:centos8.3.2011
 
-LABEL org.opencontainers.image.title="huawei-csi-plugin"
-LABEL org.opencontainers.image.description="A docker image containing the Huawei CSI plugin for k8s"
 LABEL org.opencontainers.image.authors="Adfinis AG <https://adfinis.com>"
 LABEL org.opencontainers.image.vendor="Adfinis"
-LABEL org.opencontainers.image.url="https://github.com/adfinis-sygroup/huawei-csi-plugin"
-LABEL org.opencontainers.image.licenses="AGPL-3.0-or-later"
 
 RUN yum install -y \ 
 device-mapper-multipath \ 


### PR DESCRIPTION
Also make sure the description `A docker image containing the Huawei CSI plugin for k8s"` is added to the github repos through the settings. 